### PR TITLE
API-Key test / Configuration fails on missing listId

### DIFF
--- a/src/Controller/Api/ValidationController.php
+++ b/src/Controller/Api/ValidationController.php
@@ -31,9 +31,9 @@ class ValidationController extends AbstractController
     {
         $publicKey = $post->get('publicKey');
         $privateKey = $post->get('privateKey');
-        $listId = $post->get('listId');
+        $listName = $post->get('listName');
 
-        if (empty($listId) || empty($publicKey) || empty($privateKey)) {
+        if (empty($listName) || empty($publicKey) || empty($privateKey)) {
             return new JsonResponse(['invalid_parameters' => true], Response::HTTP_OK);
         }
 
@@ -47,7 +47,7 @@ class ValidationController extends AbstractController
         }
 
         try {
-            $response = $this->getAllProfileLists(new GetProfilesListsRequest(null, $listId));
+            $response = $this->getAllProfileLists(new GetProfilesListsRequest(null, $listName));
             $accountResponse = $responses->getRequestResponse($accountRequest);
         } catch (\Exception $e) {
             return new JsonResponse(['general_error' => true], Response::HTTP_OK);


### PR DESCRIPTION
This pull request addresses an issue where the listId parameter does not exist, but the necessary listName is available in the request. The existing code only checks for the presence of listId, publicKey, and privateKey, which causes a failure when listId is missing, even though listName is correctly provided.

###  Changes Made:

- Parameter Validation:
Updated the validation logic to check for the presence of listName since listId does not exist.
This ensures that listName along with publicKey and privateKey must be present for the request to be considered valid.

- API Call Adjustment:
Modified the API call to retrieve profile lists using listName.
This change ensures that the system handles requests correctly without the listId parameter.