### PR TITLE
Lower duplicate-job logs to info; keep unexpected failures as errors

### DIFF
--- a/src/Async/TaskHandler/ExcludedSubscribersSyncScheduledTaskHandler.php
+++ b/src/Async/TaskHandler/ExcludedSubscribersSyncScheduledTaskHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Klaviyo\Integration\Async\TaskHandler;
 
 use Klaviyo\Integration\Async\Task\ExcludedSubscribersSyncScheduledTask;
+use Klaviyo\Integration\Exception\JobAlreadyRunningException;
+use Klaviyo\Integration\Exception\JobAlreadyScheduledException;
 use Klaviyo\Integration\Model\UseCase\ScheduleBackgroundJob;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -39,6 +41,8 @@ final class ExcludedSubscribersSyncScheduledTaskHandler extends ScheduledTaskHan
             if ($isJobExcludedSubscribersSyncEnabled) {
                 $this->scheduleBackgroundJob->scheduleEventsDailyExcludedSubscribersProcessingJob();
             }
+        } catch (JobAlreadyRunningException|JobAlreadyScheduledException $e) {
+            $this->logger->info($e->getMessage());
         } catch (\Throwable $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/Async/TaskHandler/ScheduleEventJobsHandler.php
+++ b/src/Async/TaskHandler/ScheduleEventJobsHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Klaviyo\Integration\Async\TaskHandler;
 
 use Klaviyo\Integration\Async\Task\ScheduleEventJobsTask;
+use Klaviyo\Integration\Exception\JobAlreadyRunningException;
+use Klaviyo\Integration\Exception\JobAlreadyScheduledException;
 use Klaviyo\Integration\Model\UseCase\ScheduleBackgroundJob;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -34,6 +36,8 @@ final class ScheduleEventJobsHandler extends ScheduledTaskHandler
     {
         try {
             $this->scheduleBackgroundJob->scheduleEventsProcessingJob();
+        } catch (JobAlreadyRunningException|JobAlreadyScheduledException $e) {
+            $this->logger->info($e->getMessage());
         } catch (\Throwable $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/Async/TaskHandler/ScheduleFullCustomerOrderSyncTaskHandler.php
+++ b/src/Async/TaskHandler/ScheduleFullCustomerOrderSyncTaskHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Klaviyo\Integration\Async\TaskHandler;
 
 use Klaviyo\Integration\Async\Task\ScheduleFullCustomerOrderSyncTask;
+use Klaviyo\Integration\Exception\JobAlreadyRunningException;
+use Klaviyo\Integration\Exception\JobAlreadyScheduledException;
 use Klaviyo\Integration\Model\UseCase\Operation\FullCustomerOrderSyncOperation;
 use Klaviyo\Integration\Model\UseCase\ScheduleBackgroundJob;
 use Klaviyo\Integration\System\ConfigService;
@@ -39,6 +41,8 @@ final class ScheduleFullCustomerOrderSyncTaskHandler extends ScheduledTaskHandle
                 $this->logger->notice("ScheduleFullCustomerSyncTask started");
                 $this->scheduleBackgroundJob->scheduleFullCustomerOrderSyncJob($context);
             }
+        } catch (JobAlreadyRunningException|JobAlreadyScheduledException $e) {
+            $this->logger->info($e->getMessage());
         } catch (\Throwable $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/Async/TaskHandler/ScheduleFullCustomerSubsSyncTaskHandler.php
+++ b/src/Async/TaskHandler/ScheduleFullCustomerSubsSyncTaskHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Klaviyo\Integration\Async\TaskHandler;
 
 use Klaviyo\Integration\Async\Task\ScheduleFullCustomerSubsSyncTask;
+use Klaviyo\Integration\Exception\JobAlreadyRunningException;
+use Klaviyo\Integration\Exception\JobAlreadyScheduledException;
 use Klaviyo\Integration\Model\UseCase\Operation\FullCustomerSubsSyncOperation;
 use Klaviyo\Integration\Model\UseCase\ScheduleBackgroundJob;
 use Klaviyo\Integration\System\ConfigService;
@@ -39,6 +41,8 @@ final class ScheduleFullCustomerSubsSyncTaskHandler extends ScheduledTaskHandler
                 $this->logger->notice("ScheduleFullCustomerSyncTask started");
                 $this->scheduleBackgroundJob->scheduleFullCustomerSubsSyncJob($context);
             }
+        } catch (JobAlreadyRunningException|JobAlreadyScheduledException $e) {
+            $this->logger->info($e->getMessage());
         } catch (\Throwable $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/Async/TaskHandler/ScheduleFullHistoricalSyncTaskHandler.php
+++ b/src/Async/TaskHandler/ScheduleFullHistoricalSyncTaskHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Klaviyo\Integration\Async\TaskHandler;
 
 use Klaviyo\Integration\Async\Task\ScheduleFullHistoricalSyncTask;
+use Klaviyo\Integration\Exception\JobAlreadyRunningException;
+use Klaviyo\Integration\Exception\JobAlreadyScheduledException;
 use Klaviyo\Integration\Model\UseCase\ScheduleBackgroundJob;
 use Klaviyo\Integration\System\ConfigService;
 use Psr\Log\LoggerInterface;
@@ -46,6 +48,8 @@ final class ScheduleFullHistoricalSyncTaskHandler extends ScheduledTaskHandler
                 $this->logger->notice("ScheduleFullHistoricalSyncTask started");
                 $this->scheduleBackgroundJob->scheduleFullOrderSyncJob($context);
             }
+        } catch (JobAlreadyRunningException|JobAlreadyScheduledException $e) {
+            $this->logger->info($e->getMessage());
         } catch (\Throwable $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/Async/TaskHandler/ScheduleFullSubscriberSyncTaskHandler.php
+++ b/src/Async/TaskHandler/ScheduleFullSubscriberSyncTaskHandler.php
@@ -6,6 +6,8 @@ namespace Klaviyo\Integration\Async\TaskHandler;
 
 use Klaviyo\Integration\Async\Task\ScheduleFullSubscriberSyncTask;
 use Klaviyo\Integration\Model\UseCase\ScheduleBackgroundJob;
+use Klaviyo\Integration\Exception\JobAlreadyRunningException;
+use Klaviyo\Integration\Exception\JobAlreadyScheduledException;
 use Klaviyo\Integration\System\ConfigService;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Api\Context\SystemSource;
@@ -46,6 +48,8 @@ final class ScheduleFullSubscriberSyncTaskHandler extends ScheduledTaskHandler
                 $this->logger->notice("ScheduleFullSubscriberSyncTask started");
                 $this->scheduleBackgroundJob->scheduleFullSubscriberSyncJob($context);
             }
+        } catch (JobAlreadyRunningException|JobAlreadyScheduledException $e) {
+            $this->logger->info($e->getMessage());
         } catch (\Throwable $e) {
             $this->logger->error($e->getMessage());
         }

--- a/src/Model/UseCase/Operation/EventsProcessingOperation.php
+++ b/src/Model/UseCase/Operation/EventsProcessingOperation.php
@@ -7,6 +7,8 @@ namespace Klaviyo\Integration\Model\UseCase\Operation;
 use Klaviyo\Integration\Async\Message\EventsProcessingMessage;
 use Klaviyo\Integration\Configuration\ConfigurationRegistry;
 use Klaviyo\Integration\Entity\Event\EventEntity;
+use Klaviyo\Integration\Exception\JobAlreadyRunningException;
+use Klaviyo\Integration\Exception\JobAlreadyScheduledException;
 use Klaviyo\Integration\Model\Channel\GetValidChannels;
 use Klaviyo\Integration\Model\UseCase\ScheduleBackgroundJob;
 use Klaviyo\Integration\System\Tracking\EventsTrackerInterface;
@@ -225,6 +227,8 @@ class EventsProcessingOperation implements JobHandlerInterface, GeneratingHandle
                     );
                 }
             }
+        } catch (JobAlreadyRunningException|JobAlreadyScheduledException $e) {
+            $this->logger->info($e->getMessage());
         } catch (\Exception $e) {
             $this->logger->error('Unable to sync job, the reason is:'.$e->getMessage());
         }


### PR DESCRIPTION
### Summary
Duplicate job scheduling/running is expected in some flows. These were logged as errors and triggered noisy alerts without indicating a real issue. This PR lowers those to info while keeping unexpected failures at error level.

### Changes
- Catch `JobAlreadyRunningException` and `JobAlreadyScheduledException` and log at **info**.
- Keep other throwables at **error** to preserve visibility.

### Files
- src/Async/TaskHandler/ExcludedSubscribersSyncScheduledTaskHandler.php
- src/Async/TaskHandler/ScheduleEventJobsHandler.php
- src/Async/TaskHandler/ScheduleFullSubscriberSyncTaskHandler.php
- src/Async/TaskHandler/ScheduleFullHistoricalSyncTaskHandler.php
- src/Async/TaskHandler/ScheduleFullCustomerSubsSyncTaskHandler.php
- src/Async/TaskHandler/ScheduleFullCustomerOrderSyncTaskHandler.php
- src/Async/Service/EventsProcessingOperation.php

### Implementation note
```php
use Klaviyo\Integration\Exception\JobAlreadyRunningException;
use Klaviyo\Integration\Exception\JobAlreadyScheduledException;

} catch (JobAlreadyRunningException|JobAlreadyScheduledException $e) {
    $this->logger->info($e->getMessage());
} catch (\Throwable $e) {
    $this->logger->error($e->getMessage());
}
```

### Testing
Low. Behavior unchanged except for log level; genuine failures still surface as errors.

Manual run of the affected scheduled tasks to confirm expected info-level log entries and unchanged error handling.

---

PS: I've already applied these changes in our own shop, but they will be lost the next time we update the plugin.
