### PR TITLE
feat: add additional blocks to improve extensibility

### DIFF
--- a/src/Resources/views/storefront/component/buy-widget/back-in-stock-form.html.twig
+++ b/src/Resources/views/storefront/component/buy-widget/back-in-stock-form.html.twig
@@ -1,6 +1,7 @@
 {% block klaviyo_back_in_stock_form %}
     {% if product.isCloseout and product.availableStock < product.minPurchase %}
-        <div class="klaviyo-stock-notification-container">
+        {% block klaviyo_back_in_stock_container %}
+            <div class="klaviyo-stock-notification-container">
                 {% set notificationConfigurationOptions = {
                     publicApiKey:  extensionData.configuration.publicApiKey|sw_sanitize,
                     listName: extensionData.configuration.subscribersListId,
@@ -147,5 +148,6 @@
                 </div>
             {% endblock %}
         </div>
+        {% endblock %}
     {% endif %}
 {% endblock %}

--- a/src/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -3,29 +3,39 @@
 {% block buy_widget_buy_form %}
     {{ parent() }}
 
-    {% if page %}
-        {% set backInStockData = page.getExtension('klaviyoIntegrationPluginExtension').configuration.subscribersListId %}
-        {% set trackSubscribedToBackInStock = page.getExtension('klaviyoIntegrationPluginExtension').configuration.trackSubscribedToBackInStock %}
-        {% set pluginExtensionData = page.getExtension('klaviyoIntegrationPluginExtension') %}
-    {% elseif context %}
-        {% set backInStockData = context.extensions.klaviyoIntegrationPluginExtension.backInStockData %}
-        {% set trackSubscribedToBackInStock = context.getExtension('klaviyoIntegrationPluginExtension').configuration.trackSubscribedToBackInStock %}
-        {% set pluginExtensionData = context.getExtension('klaviyoIntegrationPluginExtension') %}
-    {% endif %}
-
-    {% if trackSubscribedToBackInStock and backInStockData and
-        not product.translated.customFields.klaviyo_back_in_stock_disabled %}
-        {% sw_include '@Storefront/storefront/component/buy-widget/back-in-stock-form.html.twig' with {
-            extensionData: pluginExtensionData
-        } %}
-
-        {% if product.isCloseout and product.availableStock < product.minPurchase %}
-            {% block klaviyo_back_in_stock_modal_open %}
-                <button class="btn btn-primary" data-bs-toggle="modal"
-                        style="{% if extensionData.configuration.popUpOpenBtnColor %}color: {{ extensionData.configuration.popUpOpenBtnColor }};{% endif %}{% if extensionData.configuration.popUpOpenBtnBgColor %}background-color: {{ extensionData.configuration.popUpOpenBtnBgColor }}; border-color: {{ extensionData.configuration.popUpOpenBtnBgColor }};{% endif %}"
-                        data-bs-target="#back-in-stock-modal"> {{ "klaviyo.back-in-stock.modal.openBtnLabel"|trans }}
-                </button>
-            {% endblock %}
+    {% block klaviyo_back_in_stock_modal %}
+        {% if page %}
+            {% set backInStockData = page.getExtension('klaviyoIntegrationPluginExtension').configuration.subscribersListId %}
+            {% set trackSubscribedToBackInStock = page.getExtension('klaviyoIntegrationPluginExtension').configuration.trackSubscribedToBackInStock %}
+            {% set pluginExtensionData = page.getExtension('klaviyoIntegrationPluginExtension') %}
+        {% elseif context %}
+            {% set backInStockData = context.extensions.klaviyoIntegrationPluginExtension.backInStockData %}
+            {% set trackSubscribedToBackInStock = context.getExtension('klaviyoIntegrationPluginExtension').configuration.trackSubscribedToBackInStock %}
+            {% set pluginExtensionData = context.getExtension('klaviyoIntegrationPluginExtension') %}
         {% endif %}
-    {% endif %}
+
+        {% block klaviyo_back_in_stock_modal_include %}
+            {% if trackSubscribedToBackInStock and backInStockData and
+                not product.translated.customFields.klaviyo_back_in_stock_disabled %}
+                {% block klaviyo_back_in_stock_modal_include_inner %}
+                    {% block klaviyo_back_in_stock_modal_include_form %}
+                        {% sw_include '@Storefront/storefront/component/buy-widget/back-in-stock-form.html.twig' with {
+                            extensionData: pluginExtensionData
+                        } %}
+                    {% endblock %}
+
+                    {% block klaviyo_back_in_stock_modal_open_include %}
+                        {% if product.isCloseout and product.availableStock < product.minPurchase %}
+                            {% block klaviyo_back_in_stock_modal_open %}
+                                <button class="btn btn-primary" data-bs-toggle="modal"
+                                        style="{% if extensionData.configuration.popUpOpenBtnColor %}color: {{ extensionData.configuration.popUpOpenBtnColor }};{% endif %}{% if extensionData.configuration.popUpOpenBtnBgColor %}background-color: {{ extensionData.configuration.popUpOpenBtnBgColor }}; border-color: {{ extensionData.configuration.popUpOpenBtnBgColor }};{% endif %}"
+                                        data-bs-target="#back-in-stock-modal"> {{ "klaviyo.back-in-stock.modal.openBtnLabel"|trans }}
+                                </button>
+                            {% endblock %}
+                        {% endif %}
+                    {% endblock %}
+                {% endblock %}
+            {% endif %}
+        {% endblock %}
+    {% endblock %}
 {% endblock %}

--- a/src/Resources/views/storefront/element/cms-element-buy-box.html.twig
+++ b/src/Resources/views/storefront/element/cms-element-buy-box.html.twig
@@ -1,11 +1,16 @@
 {% sw_extends '@Storefront/storefront/element/cms-element-buy-box.html.twig' %}
 {% block element_buy_box %}
-    {% if page.getExtension('klaviyoIntegrationPluginExtension').configuration.trackSubscribedToBackInStock and
-        page.extensions.klaviyoIntegrationPluginExtension.backInStockData and not page.product.translated.customFields.klaviyo_back_in_stock_disabled %}
+    {% block klaviyo_back_in_stock_form %}
+        {% if page.getExtension('klaviyoIntegrationPluginExtension').configuration.trackSubscribedToBackInStock and
+            page.extensions.klaviyoIntegrationPluginExtension.backInStockData and not page.product.translated.customFields.klaviyo_back_in_stock_disabled %}
 
-        {% sw_include '@Storefront/storefront/page/product-detail/back-in-stock-form.html.twig' with {
-            extensionData: page.getExtension('klaviyoIntegrationPluginExtension')
-        } %}
-    {% endif %}
+            {% block klaviyo_back_in_stock_form_include %}
+                {% sw_include '@Storefront/storefront/page/product-detail/back-in-stock-form.html.twig' with {
+                    extensionData: page.getExtension('klaviyoIntegrationPluginExtension')
+                } %}
+            {% endblock %}
+        {% endif %}
+    {% endblock %}
+    
     {{ parent() }}
 {% endblock %}

--- a/src/Resources/views/storefront/page/product-detail/back-in-stock-form.html.twig
+++ b/src/Resources/views/storefront/page/product-detail/back-in-stock-form.html.twig
@@ -1,6 +1,7 @@
 {% block klaviyo_back_in_stock_form %}
     {% if page.product.isCloseout and page.product.availableStock < page.product.minPurchase %}
-        <div class="klaviyo-stock-notification-container">
+        {% block klaviyo_back_in_stock_container %}
+            <div class="klaviyo-stock-notification-container">
                 {% set notificationConfigurationOptions = {
                     publicApiKey:  extensionData.configuration.publicApiKey|sw_sanitize,
                     listName: extensionData.configuration.subscribersListId,
@@ -147,5 +148,6 @@
                 </div>
             {% endblock %}
         </div>
+        {% endblock %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Adds additional Twig blocks to improve template extensibility. All new blocks are fully backwards-compatible with older Shopware versions.

The PR currently targets master-4, as we are working with Shopware 6.7.
If needed, let me know whether these optimizations should be backported.